### PR TITLE
fix interfaces so they work in a nicer go style

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -14,9 +14,6 @@ Multiaddrs have both a binary and string representation.
 
 */
 type Multiaddr interface {
-	// Equal returns whether two Multiaddrs are exactly equal
-	Equal(Multiaddr) bool
-
 	// Bytes returns the []byte representation of this Multiaddr
 	Bytes() []byte
 
@@ -27,18 +24,6 @@ type Multiaddr interface {
 	// Protocols returns the list of Protocols this Multiaddr includes
 	// will panic if protocol code incorrect (and bytes accessed incorrectly)
 	Protocols() []Protocol
-
-	// Encapsulate wraps this Multiaddr around another. For example:
-	//
-	//      /ip4/1.2.3.4 encapsulate /tcp/80 = /ip4/1.2.3.4/tcp/80
-	//
-	Encapsulate(Multiaddr) Multiaddr
-
-	// Decapsultate removes a Multiaddr wrapping. For example:
-	//
-	//      /ip4/1.2.3.4/tcp/80 decapsulate /ip4/1.2.3.4 = /tcp/80
-	//
-	Decapsulate(Multiaddr) Multiaddr
 
 	// ValueForProtocol returns the value (if any) following the specified protocol
 	ValueForProtocol(code int) (string, error)

--- a/multiaddr.go
+++ b/multiaddr.go
@@ -12,7 +12,7 @@ type multiaddr struct {
 }
 
 // NewMultiaddr parses and validates an input string, returning a *Multiaddr
-func NewMultiaddr(s string) (Multiaddr, error) {
+func NewMultiaddr(s string) (*multiaddr, error) {
 	b, err := stringToBytes(s)
 	if err != nil {
 		return nil, err
@@ -22,7 +22,7 @@ func NewMultiaddr(s string) (Multiaddr, error) {
 
 // NewMultiaddrBytes initializes a Multiaddr from a byte representation.
 // It validates it as an input string.
-func NewMultiaddrBytes(b []byte) (Multiaddr, error) {
+func NewMultiaddrBytes(b []byte) (*multiaddr, error) {
 	s, err := bytesToString(b)
 	if err != nil {
 		return nil, err
@@ -33,6 +33,10 @@ func NewMultiaddrBytes(b []byte) (Multiaddr, error) {
 // Equal tests whether two multiaddrs are equal
 func (m *multiaddr) Equal(m2 Multiaddr) bool {
 	return bytes.Equal(m.bytes, m2.Bytes())
+}
+
+func Equal(m, m2 Multiaddr) bool {
+	return bytes.Equal(m.Bytes(), m2.Bytes())
 }
 
 // Bytes returns the []byte representation of this Multiaddr
@@ -85,25 +89,20 @@ func (m *multiaddr) Protocols() []Protocol {
 }
 
 // Encapsulate wraps a given Multiaddr, returning the resulting joined Multiaddr
-func (m *multiaddr) Encapsulate(o Multiaddr) Multiaddr {
-	mb := m.bytes
+func Encapsulate(m, o Multiaddr) Multiaddr {
+	mb := m.Bytes()
 	ob := o.Bytes()
-
-	b := make([]byte, len(mb)+len(ob))
-	copy(b, mb)
-	copy(b[len(mb):], ob)
-	return &multiaddr{bytes: b}
+	return &multiaddr{bytes: append(mb, ob...)}
 }
 
 // Decapsulate unwraps Multiaddr up until the given Multiaddr is found.
-func (m *multiaddr) Decapsulate(o Multiaddr) Multiaddr {
+func Decapsulate(m, o Multiaddr) Multiaddr {
 	s1 := m.String()
 	s2 := o.String()
 	i := strings.LastIndex(s1, s2)
 	if i < 0 {
 		// if multiaddr not contained, returns a copy.
-		cpy := make([]byte, len(m.bytes))
-		copy(cpy, m.bytes)
+		cpy := m.Bytes()
 		return &multiaddr{bytes: cpy}
 	}
 

--- a/multiaddr_test.go
+++ b/multiaddr_test.go
@@ -93,31 +93,31 @@ func TestEqual(t *testing.T) {
 	m3 := newMultiaddr(t, "/ip4/127.0.0.1/tcp/1234")
 	m4 := newMultiaddr(t, "/ip4/127.0.0.1/tcp/1234/")
 
-	if m1.Equal(m2) {
+	if Equal(m1, m2) {
 		t.Error("should not be equal")
 	}
 
-	if m2.Equal(m1) {
+	if Equal(m2, m1) {
 		t.Error("should not be equal")
 	}
 
-	if !m2.Equal(m3) {
+	if !Equal(m2, m3) {
 		t.Error("should be equal")
 	}
 
-	if !m3.Equal(m2) {
+	if !Equal(m3, m2) {
 		t.Error("should be equal")
 	}
 
-	if !m1.Equal(m1) {
+	if !Equal(m1, m1) {
 		t.Error("should be equal")
 	}
 
-	if !m2.Equal(m4) {
+	if !Equal(m2, m4) {
 		t.Error("should be equal")
 	}
 
-	if !m4.Equal(m3) {
+	if !Equal(m4, m3) {
 		t.Error("should be equal")
 	}
 }
@@ -194,9 +194,8 @@ func TestBytesSplitAndJoin(t *testing.T) {
 		}
 
 		// modifying underlying bytes is fine.
-		m2 := m.(*multiaddr)
-		for i := range m2.bytes {
-			m2.bytes[i] = 0
+		for i := range m.bytes {
+			m.bytes[i] = 0
 		}
 
 		for i, a := range split {
@@ -283,19 +282,19 @@ func TestEncapsulate(t *testing.T) {
 		t.Error(err)
 	}
 
-	b := m.Encapsulate(m2)
+	b := Encapsulate(m, m2)
 	if s := b.String(); s != "/ip4/127.0.0.1/udp/1234/udp/5678" {
 		t.Error("encapsulate /ip4/127.0.0.1/udp/1234/udp/5678 failed.", s)
 	}
 
 	m3, _ := NewMultiaddr("/udp/5678")
-	c := b.Decapsulate(m3)
+	c := Decapsulate(b, m3)
 	if s := c.String(); s != "/ip4/127.0.0.1/udp/1234" {
 		t.Error("decapsulate /udp failed.", "/ip4/127.0.0.1/udp/1234", s)
 	}
 
 	m4, _ := NewMultiaddr("/ip4/127.0.0.1")
-	d := c.Decapsulate(m4)
+	d := Decapsulate(c, m4)
 	if s := d.String(); s != "" {
 		t.Error("decapsulate /ip4 failed.", "/", s)
 	}


### PR DESCRIPTION
This PR makes the go-multiaddr interface match my own views on how interfaces in go should work, namely:

1) Constructors should always return a concrete type, not an interface.
  - this means that no extra casting is required to expose extra capabilities of the underlying type. While its not a big deal for the multiaddr type, take a look at the go-datastore package for why this one matters.

And

2) Interface methods should never contain references to the type in question (or really any other types from within the same package)
  - this ensures that the same interface imported from two differently vendored packages implement eachother
